### PR TITLE
Feature/scrum 50

### DIFF
--- a/lib/Pages/ChooseBestHintPage.dart
+++ b/lib/Pages/ChooseBestHintPage.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:bias_profile/commons/ResponsiveLayout.dart';
+import 'package:bias_profile/util/util.dart';
+import 'package:bias_profile/util/RoomStatusMonitor.dart';
+
+class ChooseBestHintPage extends StatefulWidget {
+  final String roomId;
+  final String playerId;
+
+  const ChooseBestHintPage({
+    super.key,
+    required this.roomId,
+    required this.playerId,
+  });
+
+  @override
+  State<ChooseBestHintPage> createState() => _ChooseBestHintPageState();
+}
+
+class _ChooseBestHintPageState extends State<ChooseBestHintPage>
+    with RoomStatusMonitor {
+  DocumentSnapshot? _documentSnapshot;
+  List<Map<String, dynamic>> _profiles = [];
+  String? _parentPlayerId;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadRoomSnapshot();
+    startRoomStatusMonitoring(
+      widget.roomId,
+      widget.playerId,
+      skipProfileNavigation: true,
+    );
+  }
+
+  Future<void> _loadRoomSnapshot() async {
+    _documentSnapshot = await getRoomSnapshot(widget.roomId);
+    if (_documentSnapshot != null) {
+      final roomData = _documentSnapshot!.data() as Map<String, dynamic>;
+      final currentTurn = roomData['current_turn'] as Map<String, dynamic>;
+
+      _profiles = List<Map<String, dynamic>>.from(currentTurn['profiles']);
+      _parentPlayerId = currentTurn['parent_player_id'] as String;
+
+      setState(() {});
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_documentSnapshot == null) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ベストヒントを選ぼう'),
+        automaticallyImplyLeading: false,
+      ),
+      body: ResponsiveLayout(
+        breakPoints: [
+          BreakPoint(minWidth: 1024, containerWidth: 500),
+          BreakPoint(minWidth: 600, containerWidth: 500),
+          BreakPoint(minWidth: 0, containerWidth: 300),
+        ],
+        builder: (context, containerWidth) {
+          // TODO: ここにベストヒント選択のUIを実装
+          return const Center(
+            child: Text('ベストヒントを選択するUIをここに実装します'),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/components/ProfileAnswerForm.dart
+++ b/lib/components/ProfileAnswerForm.dart
@@ -37,6 +37,11 @@ class _ProfileAnswerFormState extends State<ProfileAnswerForm>
   @override
   void initState() {
     super.initState();
+    startRoomStatusMonitoring(
+      widget.roomId,
+      widget.playerId,
+      skipProfileNavigation: true, // ProfileAnswerPage上での監視なのでスキップ
+    );
   }
 
   // カード選択時の処理を共通化

--- a/lib/components/ProfileAnswerForm.dart
+++ b/lib/components/ProfileAnswerForm.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:bias_profile/components/components.dart';
 import 'package:bias_profile/util/util.dart';
 import 'package:bias_profile/util/RoomStatusMonitor.dart';
+import 'package:bias_profile/Pages/ChooseBestHintPage.dart';
 
 class ProfileAnswerForm extends StatefulWidget {
   final double containerWidth;
@@ -82,8 +83,13 @@ class _ProfileAnswerFormState extends State<ProfileAnswerForm>
               ),
               confirmButtonText: '次へ進む',
               onConfirm: () async {
-                await getRoomRef(widget.roomId)
-                    .update({'current_turn.can_start_next_turn': true});
+                Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => ChooseBestHintPage(
+                              roomId: widget.roomId,
+                              playerId: widget.playerId,
+                            )));
               });
         } else {
           showConfirmationDialog(

--- a/lib/components/ProfileAnswerForm.dart
+++ b/lib/components/ProfileAnswerForm.dart
@@ -110,8 +110,25 @@ class _ProfileAnswerFormState extends State<ProfileAnswerForm>
                 builder: (BuildContext context) =>
                     const ProgressDialog(titleText: 'ターンを開始する準備をしています。'),
               );
-              await getRoomRef(widget.roomId)
-                  .update({'current_turn.can_start_next_turn': true});
+              DocumentReference roomRef = getRoomRef(widget.roomId);
+              Map<String, dynamic> roomData =
+                  await getRoomSnapshotAsMap(widget.roomId);
+              List<dynamic> players = roomData['players'];
+
+              int playerIndex = players.indexWhere(
+                  (player) => player['player_id'] == widget.playerId);
+
+              if (playerIndex != -1) {
+                players[playerIndex]['can_start_next_turn'] = true;
+
+                await roomRef.update({
+                  'players': players,
+                });
+
+                print('プレイヤー $widget.playerId のcan_start_next_turnが更新されました。');
+              } else {
+                print('プレイヤー $widget.playerId が見つかりませんでした。');
+              }
             },
           );
         }

--- a/lib/util/RoomStatusMonitor.dart
+++ b/lib/util/RoomStatusMonitor.dart
@@ -66,8 +66,25 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
                 builder: (BuildContext context) =>
                     const ProgressDialog(titleText: 'ターンを開始する準備をしています。'),
               );
-              await getRoomRef(roomId)
-                  .update({'current_turn.can_start_next_turn': true});
+              DocumentReference roomRef = getRoomRef(roomId);
+              Map<String, dynamic> roomData =
+                  await getRoomSnapshotAsMap(roomId);
+              List<dynamic> players = roomData['players'];
+
+              int playerIndex = players
+                  .indexWhere((player) => player['player_id'] == playerId);
+
+              if (playerIndex != -1) {
+                players[playerIndex]['can_start_next_turn'] = true;
+
+                await roomRef.update({
+                  'players': players,
+                });
+
+                print('プレイヤー $playerId のcan_start_next_turnが更新されました。');
+              } else {
+                print('プレイヤー $playerId が見つかりませんでした。');
+              }
             },
           );
         });

--- a/lib/util/RoomStatusMonitor.dart
+++ b/lib/util/RoomStatusMonitor.dart
@@ -10,12 +10,14 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
   late Stream<DocumentSnapshot>? _roomStream;
   late Stream<DocumentSnapshot<Map<String, dynamic>>> _roomStreamAsMap;
   bool _hasShownCancelMessage = false;
-  int? _lastTurnCount; // 前回のターン数を保持
+  int? _lastTurnCount;
+  int? _lastParentAnswer; // 前回の親の回答を保持
 
   void startRoomStatusMonitoring(
     String roomId,
     String playerId, {
     bool isCreator = false,
+    bool skipProfileNavigation = false, // ProfileAnswerPage上での監視時はtrueを設定
   }) {
     _roomStream = getRoomSnapshotAsStream(roomId);
     _roomStreamAsMap = getRoomSnapshotAsStream(roomId)
@@ -29,6 +31,47 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
 
       final currentTurn = data['current_turn'] as Map<String, dynamic>;
       final currentTurnCount = currentTurn['turn_count'] as int? ?? 0;
+      final parentAnswer = currentTurn['parent_answer'] as int?;
+      final parentPlayerId = currentTurn['parent_player_id'] as String?;
+
+      // 親プレイヤー以外に対して、parent_answerが更新されたときにダイアログを表示
+      if (parentAnswer != null &&
+          parentAnswer != _lastParentAnswer &&
+          playerId != parentPlayerId) {
+        _lastParentAnswer = parentAnswer;
+
+        // 既存のダイアログをすべて閉じる
+        Navigator.of(context).popUntil((route) => route.isCurrent);
+
+        // 少し遅延を入れてから親の回答ダイアログを表示
+        Future.delayed(const Duration(milliseconds: 100), () {
+          final characterCards =
+              List<Map<String, dynamic>>.from(currentTurn['character_cards']);
+          final selectedCard = characterCards[parentAnswer];
+
+          showConfirmationDialog(
+            context: context,
+            title: '親が選択した人物',
+            content: Image.network(
+              selectedCard['character_card_path'],
+              width: ProfileConstants.imageWidth,
+              height: ProfileConstants.imageHeight,
+              fit: BoxFit.contain,
+            ),
+            confirmButtonText: '次に進む',
+            onConfirm: () async {
+              showDialog(
+                context: context,
+                barrierDismissible: false,
+                builder: (BuildContext context) =>
+                    const ProgressDialog(titleText: 'ターンを開始する準備をしています。'),
+              );
+              await getRoomRef(roomId)
+                  .update({'current_turn.can_start_next_turn': true});
+            },
+          );
+        });
+      }
 
       switch (data['status']) {
         case 'closed' when !isCreator && !_hasShownCancelMessage:
@@ -67,22 +110,21 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
           );
           break;
 
-        // プロフィール入力の監視を追加
         case _
-            when currentTurn['profiles'] != null &&
+            when !skipProfileNavigation && // ProfileAnswerPage上ではスキップ
+                currentTurn['profiles'] != null &&
                 currentTurn['parent_answer'] == null:
           final profiles =
               List<Map<String, dynamic>>.from(currentTurn['profiles']);
 
           if (profiles.isEmpty) {
-            break; // 空の場合は何もしない
+            break;
           }
 
           final allProfilesCompleted = profiles.every((profile) =>
               profile.containsKey('input_profile') &&
               profile['input_profile'] != null);
 
-          // 自分の入力状態を確認
           final myProfile = profiles.firstWhere(
             (profile) => profile['assigned_player_id'] == playerId,
             orElse: () => {'input_profile': null},
@@ -104,7 +146,6 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
           break;
       }
 
-      // 現在のターン数を保存
       _lastTurnCount = currentTurnCount;
       print('保存されたlastTurnCount:$_lastTurnCount');
     });
@@ -113,7 +154,8 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
   @override
   void dispose() {
     _roomStream = null;
-    _lastTurnCount = null; // リセット
+    _lastTurnCount = null;
+    _lastParentAnswer = null; // 追加
     super.dispose();
   }
 }


### PR DESCRIPTION
以下、内容を実装しました。
確認おなしゃす！

・タップした画像を拡大表示できること
・「OK」タップでparent_answerを更新し、親子それぞれの画面に正誤確認ダイアログを表示
・不正解の場合、
　親子共に「次に進む」タップで、ターン準備中ダイアログを表示させ、can_start_next_turnをtrueに更新する
・正解の場合、
　子は「次に進む」タップで、ターン準備中ダイアログを表示させ、can_start_next_turnをtrueに更新する
　親はベストヒント選択画面に遷移