### PR TITLE
Feature/scrum 52

### DIFF
--- a/lib/Pages/ChooseBestHintPage.dart
+++ b/lib/Pages/ChooseBestHintPage.dart
@@ -3,6 +3,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:bias_profile/commons/ResponsiveLayout.dart';
 import 'package:bias_profile/util/util.dart';
 import 'package:bias_profile/util/RoomStatusMonitor.dart';
+import 'package:bias_profile/components/ChooseBestHintForm.dart';
+import 'dart:math';
 
 class ChooseBestHintPage extends StatefulWidget {
   final String roomId;
@@ -22,6 +24,7 @@ class _ChooseBestHintPageState extends State<ChooseBestHintPage>
     with RoomStatusMonitor {
   DocumentSnapshot? _documentSnapshot;
   List<Map<String, dynamic>> _profiles = [];
+  List<Map<String, dynamic>> _randomizedCardsList = [];
   String? _parentPlayerId;
 
   @override
@@ -35,14 +38,61 @@ class _ChooseBestHintPageState extends State<ChooseBestHintPage>
     );
   }
 
+  // ターン数を考慮したシャッフル関数
+  List<Map<String, dynamic>> _seededShuffle(
+      List<Map<String, dynamic>> list, int turnCount) {
+    // roomIdとターン数を組み合わせてシード値を生成
+    final seed = widget.roomId.hashCode ^ turnCount;
+    final random = Random(seed);
+
+    // 元のindexを追加したリストを作成
+    final indexedList = list
+        .asMap()
+        .entries
+        .map((entry) => {...entry.value, 'original_index': entry.key})
+        .toList();
+
+    // シャッフル
+    for (var i = indexedList.length - 1; i > 0; i--) {
+      final j = random.nextInt(i + 1);
+      final temp = indexedList[i];
+      indexedList[i] = indexedList[j];
+      indexedList[j] = temp;
+    }
+    return indexedList;
+  }
+
   Future<void> _loadRoomSnapshot() async {
     _documentSnapshot = await getRoomSnapshot(widget.roomId);
     if (_documentSnapshot != null) {
       final roomData = _documentSnapshot!.data() as Map<String, dynamic>;
       final currentTurn = roomData['current_turn'] as Map<String, dynamic>;
+      final players = roomData['players'] as List<dynamic>;
+      final turnCount = currentTurn['turn_count'] as int;
 
-      _profiles = List<Map<String, dynamic>>.from(currentTurn['profiles']);
+      // プロフィールリストを取得
+      final profiles = List<Map<String, dynamic>>.from(currentTurn['profiles']);
+
+      // 各プロフィールにプレイヤーのニックネームを追加
+      _profiles = profiles.map((profile) {
+        final playerData = players.firstWhere(
+          (player) => player['player_id'] == profile['assigned_player_id'],
+          orElse: () => {'nickname': '不明なプレイヤー'},
+        );
+
+        return {
+          ...profile,
+          'player_nickname': playerData['nickname'] ?? '不明なプレイヤー',
+        };
+      }).toList();
+
+      // 親プレイヤーIDを取得
       _parentPlayerId = currentTurn['parent_player_id'] as String;
+
+      // カードリストを取得してシャッフル
+      _randomizedCardsList = _seededShuffle(
+          List<Map<String, dynamic>>.from(currentTurn['character_cards']),
+          turnCount);
 
       setState(() {});
     }
@@ -68,9 +118,14 @@ class _ChooseBestHintPageState extends State<ChooseBestHintPage>
           BreakPoint(minWidth: 0, containerWidth: 300),
         ],
         builder: (context, containerWidth) {
-          // TODO: ここにベストヒント選択のUIを実装
-          return const Center(
-            child: Text('ベストヒントを選択するUIをここに実装します'),
+          return ChooseBestHintForm(
+            containerWidth: containerWidth,
+            roomId: widget.roomId,
+            playerId: widget.playerId,
+            roomData: _documentSnapshot!,
+            randomizedCardsList: _randomizedCardsList,
+            profiles: _profiles,
+            parentPlayerId: _parentPlayerId!,
           );
         },
       ),

--- a/lib/components/ChooseBestHintForm.dart
+++ b/lib/components/ChooseBestHintForm.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+import 'package:bias_profile/commons/constants.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:bias_profile/components/components.dart';
+import 'package:bias_profile/util/util.dart';
+import 'package:bias_profile/util/RoomStatusMonitor.dart';
+
+class ChooseBestHintForm extends StatefulWidget {
+  final double containerWidth;
+  final String roomId;
+  final String playerId;
+  final DocumentSnapshot roomData;
+  final List<Map<String, dynamic>> randomizedCardsList;
+  final List<Map<String, dynamic>> profiles;
+  final String parentPlayerId;
+
+  const ChooseBestHintForm({
+    super.key,
+    required this.containerWidth,
+    required this.roomId,
+    required this.playerId,
+    required this.roomData,
+    required this.randomizedCardsList,
+    required this.profiles,
+    required this.parentPlayerId,
+  });
+
+  @override
+  State<ChooseBestHintForm> createState() => _ChooseBestHintFormState();
+}
+
+class _ChooseBestHintFormState extends State<ChooseBestHintForm>
+    with RoomStatusMonitor {
+  @override
+  void initState() {
+    super.initState();
+    startRoomStatusMonitoring(
+      widget.roomId,
+      widget.playerId,
+      skipProfileNavigation: true,
+    );
+  }
+
+  // プロフィール選択時の処理
+  Future<void> _handleProfileSelection(
+      Map<String, dynamic> profile, BuildContext context) async {
+    final playerNickname = profile['player_nickname'] ?? '不明なプレイヤー';
+
+    showConfirmationDialog(
+      context: context,
+      confirmButtonText: '決定',
+      cancelButtonText: '閉じる',
+      title: profile['profile_theme'],
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(profile['input_profile']),
+        ],
+      ),
+      onCancel: () {},
+      onConfirm: () async {
+        Navigator.pop(context);
+
+        // 確認ダイアログを表示
+        showConfirmationDialog(
+          context: context,
+          confirmButtonText: 'OK',
+          cancelButtonText: 'キャンセル',
+          title: 'このプレイヤーにポイントを付与しますか？',
+          content: Text('$playerNicknameさんのヒントをベストヒントとして選びます。'),
+          onCancel: () {},
+          onConfirm: () async {
+            showDialog(
+              context: context,
+              barrierDismissible: false,
+              builder: (BuildContext context) =>
+                  const ProgressDialog(titleText: 'ポイントを付与しています'),
+            );
+
+            // 最初にroomRefを一度だけ取得
+            DocumentReference roomRef = getRoomRef(widget.roomId);
+
+            try {
+              // Firestoreからプレイヤーデータを取得
+              Map<String, dynamic> roomData =
+                  await getRoomSnapshotAsMap(widget.roomId);
+              List<dynamic> players = roomData['players'];
+
+              // 選ばれたプレイヤーのインデックスを取得
+              int selectedPlayerIndex = players.indexWhere((player) =>
+                  player['player_id'] == profile['assigned_player_id']);
+
+              // 選ばれたプレイヤーのポイントを+1
+              if (selectedPlayerIndex != -1) {
+                int currentPoints = players[selectedPlayerIndex]['points'] ?? 0;
+                players[selectedPlayerIndex]['points'] = currentPoints + 1;
+              }
+
+              // Firestoreを更新（この時点ではcan_start_next_turnは更新しない）
+              await roomRef.update({
+                'players': players,
+              });
+
+              Navigator.pop(context); // ProgressDialogを閉じる
+
+              // 成功メッセージを表示し、次へ進むボタンが押されたときに
+              // can_start_next_turnを更新するロジックを実行
+              showConfirmationDialog(
+                context: context,
+                confirmButtonText: '次へ進む',
+                title: 'ポイントを付与しました',
+                content: Text('$playerNicknameさんにポイントを付与しました。'),
+                onConfirm: () async {
+                  // 次へ進むが押されたときに実行
+                  try {
+                    // 最新データを取得（roomRefは再利用）
+                    Map<String, dynamic> updatedRoomData =
+                        await getRoomSnapshotAsMap(widget.roomId);
+                    List<dynamic> updatedPlayers = updatedRoomData['players'];
+
+                    // 自分のプレイヤーインデックスを取得
+                    int playerIndex = updatedPlayers.indexWhere(
+                        (player) => player['player_id'] == widget.playerId);
+
+                    if (playerIndex != -1) {
+                      // can_start_next_turnをtrueに設定
+                      updatedPlayers[playerIndex]['can_start_next_turn'] = true;
+
+                      // Firestoreを更新（roomRefを再利用）
+                      await roomRef.update({
+                        'players': updatedPlayers,
+                      });
+
+                      print(
+                          'プレイヤー ${widget.playerId} のcan_start_next_turnが更新されました。');
+                    } else {
+                      print('プレイヤー ${widget.playerId} が見つかりませんでした。');
+                    }
+                  } catch (e) {
+                    print('エラーが発生しました: $e');
+
+                    // エラーメッセージを表示
+                    showConfirmationDialog(
+                      context: context,
+                      confirmButtonText: '閉じる',
+                      title: 'エラーが発生しました',
+                      content: Text('操作中にエラーが発生しました: $e'),
+                    );
+                  }
+                },
+              );
+            } catch (e) {
+              Navigator.pop(context); // ProgressDialogを閉じる
+
+              // エラーメッセージを表示
+              showConfirmationDialog(
+                context: context,
+                confirmButtonText: '閉じる',
+                title: 'エラーが発生しました',
+                content: Text('操作中にエラーが発生しました: $e'),
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+
+  // カード表示用のウィジェットを共通化
+  Widget _buildCardItem(Map<String, dynamic> card) {
+    return Flexible(
+      flex: 1,
+      child: Padding(
+        padding: EdgeInsets.all(AppDimensions.paddingMedium),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: ProfileChoiceConstants.imageWidth,
+            maxHeight: ProfileChoiceConstants.imageHeight,
+          ),
+          child: AspectRatio(
+            aspectRatio: 1.0 / 1.46,
+            child: Image.network(
+              card['character_card_path'],
+              width: ProfileChoiceConstants.imageWidth,
+              height: ProfileChoiceConstants.imageHeight,
+              fit: BoxFit.contain,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: EdgeInsets.all(AppDimensions.paddingMedium),
+            child: Container(
+              decoration: BoxDecoration(
+                color: AppColors.tertiary,
+                borderRadius: BorderRadius.circular(16.0),
+              ),
+              child: Padding(
+                padding: EdgeInsets.all(AppDimensions.paddingMedium),
+                child: Column(children: [
+                  Padding(
+                    padding: EdgeInsets.symmetric(
+                        vertical: AppDimensions.paddingMedium),
+                    child: Text(
+                      'ベストヒントを選びましょう',
+                      style: Theme.of(context).textTheme.displayMedium,
+                    ),
+                  ),
+
+                  // 上段の3つ
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: widget.randomizedCardsList
+                        .sublist(0, 3)
+                        .map(_buildCardItem)
+                        .toList(),
+                  ),
+                  // 下段の2つ
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: widget.randomizedCardsList
+                        .sublist(3, 5)
+                        .map(_buildCardItem)
+                        .toList(),
+                  ),
+                ]),
+              ),
+            ),
+          ),
+          Text('ベストヒントを選択してください'),
+          Text('選択したプレイヤーに1pt与えられます'),
+          Expanded(
+            child: ListView.separated(
+              padding: EdgeInsets.symmetric(
+                horizontal: AppDimensions.paddingMedium,
+              ),
+              itemCount: widget.profiles.length,
+              separatorBuilder: (context, index) => const Divider(),
+              itemBuilder: (context, index) {
+                final profile = widget.profiles[index];
+
+                // 親プレイヤーのプロフィールは表示しない
+                if (profile['assigned_player_id'] == widget.parentPlayerId) {
+                  return const SizedBox.shrink();
+                }
+
+                return GestureDetector(
+                  onTap: () {
+                    _handleProfileSelection(profile, context);
+                  },
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(
+                      vertical: AppDimensions.paddingSmall,
+                      horizontal: AppDimensions.paddingMedium,
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Expanded(
+                          flex: 8,
+                          child: Text(
+                            profile['profile_theme'] ?? '',
+                            style: Theme.of(context).textTheme.bodyLarge,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Expanded(
+                          flex: 4,
+                          child: Text(
+                            profile['player_nickname'] ?? '',
+                            style: Theme.of(context).textTheme.bodyLarge,
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: TextAlign.right,
+                          ),
+                        ),
+                        const Icon(
+                          Icons.arrow_right_alt_sharp,
+                          size: 16,
+                          color: Colors.grey,
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/ChooseBestHintForm.dart
+++ b/lib/components/ChooseBestHintForm.dart
@@ -46,6 +46,7 @@ class _ChooseBestHintFormState extends State<ChooseBestHintForm>
       Map<String, dynamic> profile, BuildContext context) async {
     final playerNickname = profile['player_nickname'] ?? '不明なプレイヤー';
 
+    // まず詳細表示ダイアログを表示
     showConfirmationDialog(
       context: context,
       confirmButtonText: '決定',
@@ -62,7 +63,7 @@ class _ChooseBestHintFormState extends State<ChooseBestHintForm>
       onConfirm: () async {
         Navigator.pop(context);
 
-        // 確認ダイアログを表示
+        // ポイント付与確認ダイアログを表示
         showConfirmationDialog(
           context: context,
           confirmButtonText: 'OK',
@@ -78,7 +79,7 @@ class _ChooseBestHintFormState extends State<ChooseBestHintForm>
                   const ProgressDialog(titleText: 'ポイントを付与しています'),
             );
 
-            // 最初にroomRefを一度だけ取得
+            // roomRefを一度だけ取得
             DocumentReference roomRef = getRoomRef(widget.roomId);
 
             try {
@@ -97,59 +98,61 @@ class _ChooseBestHintFormState extends State<ChooseBestHintForm>
                 players[selectedPlayerIndex]['points'] = currentPoints + 1;
               }
 
-              // Firestoreを更新（この時点ではcan_start_next_turnは更新しない）
+              // Firestoreを更新（ポイントのみ更新）
               await roomRef.update({
                 'players': players,
               });
 
               Navigator.pop(context); // ProgressDialogを閉じる
 
-              // 成功メッセージを表示し、次へ進むボタンが押されたときに
-              // can_start_next_turnを更新するロジックを実行
-              showConfirmationDialog(
+              // 成功メッセージとプログレスインジケーターを表示（自動的に閉じる）
+              showDialog(
                 context: context,
-                confirmButtonText: '次へ進む',
-                title: 'ポイントを付与しました',
-                content: Text('$playerNicknameさんにポイントを付与しました。'),
-                onConfirm: () async {
-                  // 次へ進むが押されたときに実行
-                  try {
-                    // 最新データを取得（roomRefは再利用）
-                    Map<String, dynamic> updatedRoomData =
-                        await getRoomSnapshotAsMap(widget.roomId);
-                    List<dynamic> updatedPlayers = updatedRoomData['players'];
-
-                    // 自分のプレイヤーインデックスを取得
-                    int playerIndex = updatedPlayers.indexWhere(
-                        (player) => player['player_id'] == widget.playerId);
-
-                    if (playerIndex != -1) {
-                      // can_start_next_turnをtrueに設定
-                      updatedPlayers[playerIndex]['can_start_next_turn'] = true;
-
-                      // Firestoreを更新（roomRefを再利用）
-                      await roomRef.update({
-                        'players': updatedPlayers,
-                      });
-
-                      print(
-                          'プレイヤー ${widget.playerId} のcan_start_next_turnが更新されました。');
-                    } else {
-                      print('プレイヤー ${widget.playerId} が見つかりませんでした。');
-                    }
-                  } catch (e) {
-                    print('エラーが発生しました: $e');
-
-                    // エラーメッセージを表示
-                    showConfirmationDialog(
-                      context: context,
-                      confirmButtonText: '閉じる',
-                      title: 'エラーが発生しました',
-                      content: Text('操作中にエラーが発生しました: $e'),
-                    );
-                  }
+                barrierDismissible: false,
+                builder: (BuildContext context) {
+                  return AlertDialog(
+                    title: Text('ポイントを付与しました'),
+                    content: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Text('他のプレイヤーの準備待ち...'),
+                        const SizedBox(height: 16),
+                        const CircularProgressIndicator(),
+                      ],
+                    ),
+                  );
                 },
               );
+
+              // 3秒後に自動的にダイアログを閉じ、その後can_start_next_turnを更新
+              await Future.delayed(
+                  Duration(seconds: AppDurations.processingDuration));
+
+              // 既存のダイアログをすべて閉じる
+              Navigator.of(context).popUntil((route) => route.isCurrent);
+
+              // 最新のプレイヤーデータを再取得
+              Map<String, dynamic> updatedRoomData =
+                  await getRoomSnapshotAsMap(widget.roomId);
+              List<dynamic> updatedPlayers = updatedRoomData['players'];
+
+              // 自分のプレイヤーインデックスを取得
+              int playerIndex = updatedPlayers.indexWhere(
+                  (player) => player['player_id'] == widget.playerId);
+
+              if (playerIndex != -1) {
+                // can_start_next_turnをtrueに設定
+                updatedPlayers[playerIndex]['can_start_next_turn'] = true;
+
+                // Firestoreを更新（can_start_next_turnのみ）
+                await roomRef.update({
+                  'players': updatedPlayers,
+                });
+
+                print(
+                    '3秒後にプレイヤー ${widget.playerId} のcan_start_next_turnが更新されました。');
+              }
             } catch (e) {
               Navigator.pop(context); // ProgressDialogを閉じる
 
@@ -159,6 +162,7 @@ class _ChooseBestHintFormState extends State<ChooseBestHintForm>
                 confirmButtonText: '閉じる',
                 title: 'エラーが発生しました',
                 content: Text('操作中にエラーが発生しました: $e'),
+                onCancel: () {},
               );
             }
           },
@@ -237,8 +241,10 @@ class _ChooseBestHintFormState extends State<ChooseBestHintForm>
               ),
             ),
           ),
-          Text('ベストヒントを選択してください'),
-          Text('選択したプレイヤーに1pt与えられます'),
+          Padding(
+            padding: EdgeInsets.all(AppDimensions.paddingMedium),
+            child: Text('ベストヒントを選択してください\n選択したプレイヤーに1pt与えられます'),
+          ),
           Expanded(
             child: ListView.separated(
               padding: EdgeInsets.symmetric(

--- a/lib/components/ProfileAnswerForm.dart
+++ b/lib/components/ProfileAnswerForm.dart
@@ -72,6 +72,34 @@ class _ProfileAnswerFormState extends State<ProfileAnswerForm>
         Navigator.pop(context);
 
         if (isCorrect && widget.isParentPlayer) {
+          // 正解の場合、親プレイヤーにポイントを追加
+          try {
+            // Firestoreからプレイヤーデータを取得
+            DocumentReference roomRef = getRoomRef(widget.roomId);
+            Map<String, dynamic> roomData =
+                await getRoomSnapshotAsMap(widget.roomId);
+            List<dynamic> players = roomData['players'];
+
+            // 自分（親プレイヤー）のインデックスを取得
+            int playerIndex = players
+                .indexWhere((player) => player['player_id'] == widget.playerId);
+
+            if (playerIndex != -1) {
+              // ポイントを+1
+              int currentPoints = players[playerIndex]['points'] ?? 0;
+              players[playerIndex]['points'] = currentPoints + 1;
+
+              // Firestoreを更新
+              await roomRef.update({
+                'players': players,
+              });
+
+              print('親プレイヤー ${widget.playerId} にポイントが付与されました。');
+            }
+          } catch (e) {
+            print('ポイント付与中にエラーが発生しました: $e');
+          }
+
           showConfirmationDialog(
               context: context,
               title: '正解！！',

--- a/lib/util/RoomStatusMonitor.dart
+++ b/lib/util/RoomStatusMonitor.dart
@@ -12,6 +12,7 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
   bool _hasShownCancelMessage = false;
   int? _lastTurnCount;
   int? _lastParentAnswer; // 前回の親の回答を保持
+  bool _isProcessingTurnChange = false; // ターンの変更処理中かどうかを示すフラグ
 
   void startRoomStatusMonitoring(
     String roomId,
@@ -103,18 +104,42 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
           break;
 
         case _
-            when _lastTurnCount != null && currentTurnCount > _lastTurnCount!:
+            when _lastTurnCount != null &&
+                currentTurnCount > _lastTurnCount! &&
+                !_isProcessingTurnChange:
+          // ターン変更処理中フラグをセット
+          _isProcessingTurnChange = true;
+
           print('lastTurnCount:$_lastTurnCount');
           print('currentTurnCount:$currentTurnCount');
           print('ターン数の増加を検知');
+
+          // 既存のダイアログをすべて閉じる
+          Navigator.of(context).popUntil((route) => route.isCurrent);
+
+          // 少し遅延を入れてからダイアログを表示（他のダイアログが完全に閉じるのを待つ）
+          await Future.delayed(const Duration(milliseconds: 100));
+
+          if (!mounted) {
+            _isProcessingTurnChange = false;
+            return;
+          }
+
           showDialog(
             context: context,
             barrierDismissible: false,
             builder: (BuildContext context) =>
                 ProgressDialog(titleText: 'ターンを開始する準備をしています。'),
           );
+
           await Future.delayed(
               Duration(seconds: AppDurations.processingDuration));
+
+          if (!mounted) {
+            _isProcessingTurnChange = false;
+            return;
+          }
+
           Navigator.pushReplacement(
             context,
             MaterialPageRoute(
@@ -125,6 +150,9 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
               ),
             ),
           );
+
+          // フラグをリセット
+          _isProcessingTurnChange = false;
           break;
 
         case _
@@ -148,7 +176,9 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
           );
 
           if (allProfilesCompleted) {
+            // 既存のダイアログをすべて閉じる
             Navigator.of(context).popUntil((route) => route.isFirst);
+
             Navigator.pushReplacement(
               context,
               MaterialPageRoute(
@@ -172,7 +202,8 @@ mixin RoomStatusMonitor<T extends StatefulWidget> on State<T> {
   void dispose() {
     _roomStream = null;
     _lastTurnCount = null;
-    _lastParentAnswer = null; // 追加
+    _lastParentAnswer = null;
+    _isProcessingTurnChange = false;
     super.dispose();
   }
 }


### PR DESCRIPTION
以下、内容を実装しました

・画像の並び順は、回答画面と同じが望ましい
・各プロフィールのリストをタップで、プロフィール確認ダイアログを表示し入力内容が確認できる
・「OK」タップで当該プレイヤーのポイントを+1し、自身のcan_start_next_turnをtrueに更新